### PR TITLE
Fix indentation in AC_DebugMode class

### DIFF
--- a/src/main/java/dev/adventurecraft/awakening/common/AC_DebugMode.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_DebugMode.java
@@ -7,8 +7,8 @@ public class AC_DebugMode {
 	public static AC_MapEditing mapEditing = null;
 	public static boolean renderPaths = false;
 	public static int reachDistance = 4;
-    public static boolean renderFov = false;
-    public static boolean renderCollisions = false;
+	public static boolean renderFov = false;
+	public static boolean renderCollisions = false;
 
 	public static boolean triggerResetActive = false;
 	public static boolean isFluidHittable = true;


### PR DESCRIPTION
This PR fixes the indentation in the AC_DebugMode class file by replacing the mismatched indentation with a single tab character just like the surrounding elements in the code.

This PR is in response to the following direct message exchange over DIscord:
![image](https://github.com/Adventurecraft-Awakening/AC-Legacy-Mod/assets/32451103/dc1d2db4-eea9-44f8-baa4-150f2215b5b4)
