### PR TITLE
Power glove block fix

### DIFF
--- a/src/main/java/dev/adventurecraft/awakening/common/AC_ItemPowerGlove.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_ItemPowerGlove.java
@@ -19,19 +19,27 @@ public class AC_ItemPowerGlove extends Item {
 
     /**
      * Uses the current item to push a given block.
-     * @param stack The current power glove item stack.
+     *
+     * @param stack  The current power glove item stack.
      * @param player The player that is trying to move the block
-     * @param world The block in which the block is being moved
-     * @param x The x position of the block
-     * @param y The y position of the block
-     * @param z The z position of the block
-     * @param side The side from which the block was moved.
+     * @param world  The block in which the block is being moved
+     * @param x      The x position of the block
+     * @param y      The y position of the block
+     * @param z      The z position of the block
+     * @param side   The side from which the block was moved.
      * @return false if the move operation was unsuccessful. Otherwise, true.
      */
     @Override
     public boolean useOnBlock(ItemStack stack, PlayerEntity player, World world, int x, int y, int z, int side) {
         boolean currentBlockExists = currentFallingBlock != null && !currentFallingBlock.removed;
-        if (currentBlockExists) return false;
+        if (currentBlockExists) {
+            // Saving and exiting while the block is falling keeps the falling block entity saved to the item.
+            // The glove thinks there is a falling block, but it isn't on the current world.
+            // This means that the player cannot use the power glove until the game is reset.
+            // So we check if the currently tracked falling block is on this world.
+            if (currentFallingBlock.world == world) return false;
+            else currentFallingBlock = null;
+        }
         int xDir = 0;
         int zDir = 0;
 
@@ -53,7 +61,7 @@ public class AC_ItemPowerGlove extends Item {
         }
 
         int currentBlockId = world.getBlockId(x, y, z);
-        boolean isPushableBlock =  currentBlockId != AC_Blocks.pushableBlock.id;
+        boolean isPushableBlock = currentBlockId != AC_Blocks.pushableBlock.id;
 
         if (!isPushableBlock) return false;
 

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_ItemPowerGlove.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_ItemPowerGlove.java
@@ -34,9 +34,10 @@ public class AC_ItemPowerGlove extends Item {
         boolean currentBlockExists = currentFallingBlock != null && !currentFallingBlock.removed;
         if (currentBlockExists) {
             // Saving and exiting while the block is falling keeps the falling block entity saved to the item.
-            // The glove thinks there is a falling block, but it isn't on the current world.
-            // This means that the player cannot use the power glove until the game is reset.
-            // So we check if the currently tracked falling block is on this world.
+            // In this case, the glove thinks there is a falling block, but it isn't on the current world.
+            // This would mean that the player would not be able to use the power glove until the game is reset.
+            // So we check if the currently tracked falling block is on this world:
+            // If it is, do nothing (fail to push), if not, unset it and proceed with the push.
             if (currentFallingBlock.world == world) return false;
             else currentFallingBlock = null;
         }

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_ItemPowerGlove.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_ItemPowerGlove.java
@@ -16,6 +16,18 @@ public class AC_ItemPowerGlove extends Item {
     }
 
     private FallingBlockEntity currentFallingBlock = null;
+
+    /**
+     * Uses the current item to push a given block.
+     * @param stack The current power glove item stack.
+     * @param player The player that is trying to move the block
+     * @param world The block in which the block is being moved
+     * @param x The x position of the block
+     * @param y The y position of the block
+     * @param z The z position of the block
+     * @param side The side from which the block was moved.
+     * @return false if the move operation was unsuccessful. Otherwise, true.
+     */
     @Override
     public boolean useOnBlock(ItemStack stack, PlayerEntity player, World world, int x, int y, int z, int side) {
         boolean currentBlockExists = currentFallingBlock != null && !currentFallingBlock.removed;


### PR DESCRIPTION
A fix for Issue #6. This change saves a power glove's current falling block and doesn't allow it to push/pull until that falling block is null again or removed.

Currently asking in Discord/#wendys if this change could/would break any maps, as it disables simultaneous block pushing.