### PR TITLE
Hookshot issues fix

### DIFF
--- a/src/main/java/dev/adventurecraft/awakening/common/AC_ItemHookshot.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_ItemHookshot.java
@@ -58,6 +58,7 @@ public class AC_ItemHookshot extends Item {
             onMainHand = false;
         }
 
+        // The hook exists if there is a reference, it is not removed, and it is on the current world.
         boolean mainHookExists = !(mainHook == null || mainHook.removed || mainHook.world != world);
         boolean offHookExists = !(offHook == null || offHook.removed || offHook.world != world);
         boolean playerIsSwimming = player.method_1335() || player.method_1393(); // In lava and water respectively.

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_ItemHookshot.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_ItemHookshot.java
@@ -1,7 +1,6 @@
 package dev.adventurecraft.awakening.common;
 
 import dev.adventurecraft.awakening.extension.entity.player.ExPlayerEntity;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_ItemHookshot.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_ItemHookshot.java
@@ -20,6 +20,22 @@ public class AC_ItemHookshot extends Item {
         this.maxStackSize = 1;
     }
 
+    /**
+     * Removes the existing hookshots and references to them.
+     * NOTE: Should this information be saved in the player entity instead for multiplayer purposes or future proofing?
+     *       Maybe as an implemented interface for extra cleanliness?
+     */
+    public void resetPlayerHookshotState() {
+        if (mainHookshot != null) {
+            mainHookshot.remove();
+            mainHookshot = null;
+        }
+        if (offHookshot != null) {
+            offHookshot.remove();
+            offHookshot = null;
+        }
+    }
+
     public boolean shouldSpinWhenRendering() {
         return true;
     }

--- a/src/main/java/dev/adventurecraft/awakening/mixin/entity/player/MixinPlayerEntity.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/entity/player/MixinPlayerEntity.java
@@ -83,9 +83,7 @@ public abstract class MixinPlayerEntity extends MixinLivingEntity implements ExP
 
     @Inject(method = "afterSpawn", at = @At("TAIL"))
     private void resetAfterSpawn(CallbackInfo ci) {
-        // Reset hookshot state
-        AC_Items.hookshot.mainHookshot = null;
-        AC_Items.hookshot.offHookshot = null;
+        AC_Items.hookshot.resetPlayerHookshotState();
         this.removed = false;
         this.fireTicks = -this.field_1646;
     }

--- a/src/main/java/dev/adventurecraft/awakening/mixin/entity/player/MixinPlayerEntity.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/entity/player/MixinPlayerEntity.java
@@ -83,6 +83,9 @@ public abstract class MixinPlayerEntity extends MixinLivingEntity implements ExP
 
     @Inject(method = "afterSpawn", at = @At("TAIL"))
     private void resetAfterSpawn(CallbackInfo ci) {
+        // Reset hookshot state
+        AC_Items.hookshot.mainHookshot = null;
+        AC_Items.hookshot.offHookshot = null;
         this.removed = false;
         this.fireTicks = -this.field_1646;
     }


### PR DESCRIPTION
Solves Hookshot hovering (#25) (Sorry Zelda Adventure speedrunner) by removing the hookshot entities and their references on player spawn.

Partially fixes breaking on relog (now a graphical glitch only) (#26) by checking the world of the existing entity before firing.