### PR TITLE
Fixed a bug that double-clicked all buttons on the AC Gui Palette

### DIFF
--- a/src/main/java/dev/adventurecraft/awakening/common/AC_GuiPalette.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_GuiPalette.java
@@ -110,7 +110,6 @@ public class AC_GuiPalette extends DoubleChestScreen {
                 if (button.isMouseOver(this.client, mouseX, mouseY)) {
                     this.prevButton = button;
                     this.client.soundHelper.playSound("random.click", 1.0F, 1.0F);
-                    this.buttonClicked(button);
                 }
             }
         }


### PR DESCRIPTION
My bad. Next and Prev buttons were being called twice; once on mouseClicked and another time on super.mouseClicked (essentially super.super.mouseClicked)