### PR TITLE
GitHub issue fixes

### DIFF
--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockEffect.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockEffect.java
@@ -192,7 +192,7 @@ public class AC_BlockEffect extends BlockWithEntity implements AC_ITriggerBlock 
 
     @Override
     public boolean canUse(World world, int x, int y, int z, PlayerEntity player) {
-        if (AC_DebugMode.active && player.getHeldItem() != null && player.getHeldItem().itemId == AC_Items.cursor.id) {
+        if (AC_DebugMode.active && (player.getHeldItem() == null || player.getHeldItem().itemId == AC_Items.cursor.id)) {
             var entity = (AC_TileEntityEffect) world.getBlockEntity(x, y, z);
             AC_GuiEffect.showUI(entity);
             return true;

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockHealDamage.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockHealDamage.java
@@ -65,7 +65,7 @@ public class AC_BlockHealDamage extends BlockWithEntity implements AC_ITriggerBl
 
     @Override
     public boolean canUse(World world, int x, int y, int z, PlayerEntity player) {
-        if (AC_DebugMode.active && player.getHeldItem() != null && player.getHeldItem().itemId == AC_Items.cursor.id) {
+        if (AC_DebugMode.active && (player.getHeldItem() == null || player.getHeldItem().itemId == AC_Items.cursor.id)) {
             var entity = (AC_TileEntityHealDamage) world.getBlockEntity(x, y, z);
             AC_GuiHealDamage.showUI(world, entity);
             return true;

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockMusic.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockMusic.java
@@ -58,7 +58,7 @@ public class AC_BlockMusic extends BlockWithEntity implements AC_ITriggerBlock {
 
     @Override
     public boolean canUse(World world, int x, int y, int z, PlayerEntity player) {
-        if (AC_DebugMode.active && player.getHeldItem() != null && player.getHeldItem().itemId == AC_Items.cursor.id) {
+        if (AC_DebugMode.active && (player.getHeldItem() == null || player.getHeldItem().itemId == AC_Items.cursor.id)) {
             var entity = (AC_TileEntityMusic) world.getBlockEntity(x, y, z);
             AC_GuiMusic.showUI(world, entity);
             return true;

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockNpcPath.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockNpcPath.java
@@ -54,7 +54,7 @@ public class AC_BlockNpcPath extends BlockWithEntity implements AC_ITriggerBlock
 
     @Override
     public boolean canUse(World world, int x, int y, int z, PlayerEntity player) {
-        if (AC_DebugMode.active && player.getHeldItem() != null && player.getHeldItem().itemId == AC_Items.cursor.id) {
+        if (AC_DebugMode.active && (player.getHeldItem() == null || player.getHeldItem().itemId == AC_Items.cursor.id)) {
             var entity = (AC_TileEntityNpcPath) world.getBlockEntity(x, y, z);
             if (entity != null) {
                 AC_GuiNpcPath.showUI(entity);

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockRedstoneTrigger.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockRedstoneTrigger.java
@@ -50,13 +50,14 @@ public class AC_BlockRedstoneTrigger extends BlockWithEntity implements AC_ITrig
     }
 
     @Override
-    public boolean canUse(World var1, int var2, int var3, int var4, PlayerEntity var5) {
-        if (AC_DebugMode.active && var5.getHeldItem() != null && var5.getHeldItem().itemId == AC_Items.cursor.id) {
-            var entity = (AC_TileEntityRedstoneTrigger) var1.getBlockEntity(var2, var3, var4);
-            AC_GuiRedstoneTrigger.showUI(var1, var2, var3, var4, entity);
+    public boolean canUse(World world, int x, int y, int z, PlayerEntity player) {
+        if (AC_DebugMode.active && (player.getHeldItem() == null || player.getHeldItem().itemId == AC_Items.cursor.id)) {
+            var entity = (AC_TileEntityRedstoneTrigger) world.getBlockEntity(x, y, z);
+            AC_GuiRedstoneTrigger.showUI(world, x, y, z, entity);
+            return true;
+        } else {
+            return false;
         }
-
-        return true;
     }
 
     public void setTriggerToSelection(World world, int x, int y, int z) {

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTrigger.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTrigger.java
@@ -141,7 +141,11 @@ public class AC_BlockTrigger extends BlockWithEntity implements AC_ITriggerBlock
         }
 
         var tileEntity = (AC_TileEntityTrigger) world.getBlockEntity(x, y, z);
-        if (!this.isAlreadyActivated(world, x, y, z)) {
+        // Treat trigger blocks with no set as if they are not trigger blocks
+        if(!tileEntity.isSet()){
+            return;
+        }
+        else if (!this.isAlreadyActivated(world, x, y, z)) {
             if (!tileEntity.resetOnTrigger) {
                 ((ExWorld) world).getTriggerManager().addArea(x, y, z, new AC_TriggerArea(tileEntity.minX, tileEntity.minY, tileEntity.minZ, tileEntity.maxX, tileEntity.maxY, tileEntity.maxZ));
             } else {
@@ -217,7 +221,6 @@ public class AC_BlockTrigger extends BlockWithEntity implements AC_ITriggerBlock
 
     @Override
     public boolean canUse(World world, int x, int y, int z, PlayerEntity player) {
-        // #79 place trigger blocks on trigger blocks + #5 open trigger gui with hand or cursor, everything else (see else) places the block
         if (AC_DebugMode.active  && (player.getHeldItem() == null || player.getHeldItem().itemId == AC_Items.cursor.id)) {
             var entity = (AC_TileEntityTrigger) world.getBlockEntity(x, y, z);
             AC_GuiTrigger.showUI(world, x, y, z, entity);

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTrigger.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTrigger.java
@@ -148,9 +148,9 @@ public class AC_BlockTrigger extends BlockWithEntity implements AC_ITriggerBlock
                 ExBlock.resetArea(world, tileEntity.minX, tileEntity.minY, tileEntity.minZ, tileEntity.maxX, tileEntity.maxY, tileEntity.maxZ);
             }
         }
-        // If player is dead, set activated to 0 so that the triggerArea can be removed!
+        // If player is dead, set activated to 1 so that the triggerArea can be removed in AC_TileEntityTrigger!
         if (((PlayerEntity) entity).health <= 0){
-            tileEntity.activated = 0;
+            tileEntity.activated = 1;
         }
         else {
             tileEntity.activated = 2;
@@ -217,9 +217,13 @@ public class AC_BlockTrigger extends BlockWithEntity implements AC_ITriggerBlock
 
     @Override
     public boolean canUse(World world, int x, int y, int z, PlayerEntity player) {
-        if (AC_DebugMode.active && player.getHeldItem() != null && player.getHeldItem().itemId == AC_Items.cursor.id) {
+        // #79 place trigger blocks on trigger blocks + #5 open trigger gui with hand or cursor, everything else (see else) places the block
+        if (AC_DebugMode.active  && (player.getHeldItem() == null || player.getHeldItem().itemId == AC_Items.cursor.id)) {
             var entity = (AC_TileEntityTrigger) world.getBlockEntity(x, y, z);
             AC_GuiTrigger.showUI(world, x, y, z, entity);
+        }
+        else {
+            return false;
         }
         return true;
     }

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTrigger.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTrigger.java
@@ -148,7 +148,13 @@ public class AC_BlockTrigger extends BlockWithEntity implements AC_ITriggerBlock
                 ExBlock.resetArea(world, tileEntity.minX, tileEntity.minY, tileEntity.minZ, tileEntity.maxX, tileEntity.maxY, tileEntity.maxZ);
             }
         }
-        tileEntity.activated = 2;
+        // If player is dead, set activated to 0 so that the triggerArea can be removed!
+        if (((PlayerEntity) entity).health <= 0){
+            tileEntity.activated = 0;
+        }
+        else {
+            tileEntity.activated = 2;
+        }
     }
 
     public void deactivateTrigger(World world, int x, int y, int z) {

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTriggerInverter.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTriggerInverter.java
@@ -87,7 +87,7 @@ public class AC_BlockTriggerInverter extends BlockWithEntity implements AC_ITrig
 
     @Override
     public boolean canUse(World world, int x, int y, int z, PlayerEntity player) {
-        if (AC_DebugMode.active && player.getHeldItem() != null && player.getHeldItem().itemId == AC_Items.cursor.id) {
+        if (AC_DebugMode.active && (player.getHeldItem() == null || player.getHeldItem().itemId == AC_Items.cursor.id)) {
             var entity = (AC_TileEntityTriggerInverter) world.getBlockEntity(x, y, z);
             AC_GuiTriggerInverter.showUI(world, x, y, z, entity);
             return true;

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTriggerMemory.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTriggerMemory.java
@@ -112,7 +112,7 @@ public class AC_BlockTriggerMemory extends BlockWithEntity implements AC_ITrigge
 
     @Override
     public boolean canUse(World world, int x, int y, int z, PlayerEntity player) {
-        if (AC_DebugMode.active && player.getHeldItem() != null && player.getHeldItem().itemId == AC_Items.cursor.id) {
+        if (AC_DebugMode.active && (player.getHeldItem() == null || player.getHeldItem().itemId == AC_Items.cursor.id)) {
             var entity = (AC_TileEntityTriggerMemory) world.getBlockEntity(x, y, z);
             AC_GuiTriggerMemory.showUI(world, x, y, z, entity);
             return true;

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTriggerPushable.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTriggerPushable.java
@@ -59,7 +59,7 @@ public class AC_BlockTriggerPushable extends AC_BlockColorWithEntity {
 
     @Override
     public boolean canUse(World world, int x, int y, int z, PlayerEntity player) {
-        if (AC_DebugMode.active && player.getHeldItem() != null && player.getHeldItem().itemId == AC_Items.cursor.id) {
+        if (AC_DebugMode.active && (player.getHeldItem() == null || player.getHeldItem().itemId == AC_Items.cursor.id)) {
             var entity = (AC_TileEntityTriggerPushable) world.getBlockEntity(x, y, z);
             AC_GuiTriggerPushable.showUI(entity);
             return true;

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTriggeredDoor.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTriggeredDoor.java
@@ -10,6 +10,7 @@ import net.minecraft.world.World;
 
 public class AC_BlockTriggeredDoor extends Block implements AC_ITriggerBlock {
 
+    private boolean isActived = false;
     protected AC_BlockTriggeredDoor(int var1) {
         super(var1, Material.WOOD);
         this.texture = 208;
@@ -22,7 +23,7 @@ public class AC_BlockTriggeredDoor extends Block implements AC_ITriggerBlock {
 
     @Override
     public boolean isCollidable() {
-        return true;
+        return AC_DebugMode.active || this.isActived;
     }
 
     @Override
@@ -47,11 +48,13 @@ public class AC_BlockTriggeredDoor extends Block implements AC_ITriggerBlock {
     public void onTriggerActivated(World world, int x, int y, int z) {
         world.playSound((double) x + 0.5D, (double) y + 0.5D, (double) z + 0.5D, "random.door_open", 1.0F, world.rand.nextFloat() * 0.1F + 0.9F);
         world.notifyListeners(x, y, z);
+        this.isActived = true;
     }
 
     @Override
     public void onTriggerDeactivated(World world, int x, int y, int z) {
         world.playSound((double) x + 0.5D, (double) y + 0.5D, (double) z + 0.5D, "random.door_close", 1.0F, world.rand.nextFloat() * 0.1F + 0.9F);
         world.notifyListeners(x, y, z);
+        this.isActived = false;
     }
 }

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTriggeredDoor.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockTriggeredDoor.java
@@ -22,7 +22,7 @@ public class AC_BlockTriggeredDoor extends Block implements AC_ITriggerBlock {
 
     @Override
     public boolean isCollidable() {
-        return AC_DebugMode.active;
+        return true;
     }
 
     @Override

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_BlockWeather.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_BlockWeather.java
@@ -69,7 +69,7 @@ public class AC_BlockWeather extends BlockWithEntity implements AC_ITriggerBlock
 
     @Override
     public boolean canUse(World world, int x, int y, int z, PlayerEntity player) {
-        if (AC_DebugMode.active && player.getHeldItem() != null && player.getHeldItem().itemId == AC_Items.cursor.id) {
+        if (AC_DebugMode.active && (player.getHeldItem() == null || player.getHeldItem().itemId == AC_Items.cursor.id)) {
             var entity = (AC_TileEntityWeather) world.getBlockEntity(x, y, z);
             AC_GuiWeather.showUI(world, entity);
             return true;

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_EntityLivingScript.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_EntityLivingScript.java
@@ -187,8 +187,12 @@ public class AC_EntityLivingScript extends LivingEntity implements IEntityPather
 
     private boolean runOnAttackedScript() {
         if (!this.onAttacked.equals("")) {
-            ((ExWorld) this.world).getScript().setNewScope(this.scope);
+            // Save curscope temporary
+            Scriptable tempScope = ((ExWorld) this.world).getScript().getCurScope();
+            ((ExWorld) this.world).getScript().setNewCurScope(this.scope);
             Object result = ((ExWorld) this.world).getScriptHandler().runScript(this.onAttacked, this.scope);
+            // Reset curScope afterwards! IMPORTANT for normal damage scripts
+            ((ExWorld) this.world).getScript().setNewCurScope(tempScope);
             return result instanceof Boolean b ? b : true;
         } else {
             return true;

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_ItemCustom.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_ItemCustom.java
@@ -78,10 +78,18 @@ public class AC_ItemCustom extends Item implements AC_IUseDelayItem {
                 this.maxStackSize = value;
             }
         }
+        // configurable itemUseDelay
+        this.itemUseDelay = 1; // Default
+        String sItemUseDelay = properties.getProperty("itemUseDelay");
+        if (sItemUseDelay != null) {
+            Integer value = this.loadPropertyInt("itemUseDelay", sItemUseDelay);
+            if (value != null) {
+                this.itemUseDelay = value;
+            }
+        }
 
         this.setTranslationKey(properties.getProperty("name", "Unnamed"));
         this.onItemUsedScript = properties.getProperty("onItemUsedScript", "");
-        this.itemUseDelay = 1;
     }
 
     private Integer loadPropertyInt(String name, String value) {

--- a/src/main/java/dev/adventurecraft/awakening/common/AC_ModelBat.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/AC_ModelBat.java
@@ -15,19 +15,19 @@ public class AC_ModelBat extends EntityModel {
     public AC_ModelBat() {
         float var1 = 16.0F;
         this.theHead = new Cuboid(0, 0);
-        this.theHead.method_1818(-1.5F, -3.0F, -1.5F, 3, 3, 3, 0.0F);
+        this.theHead.method_1818(-1.5F, 5.0F, -1.5F, 3, 3, 3, 0.0F);
         this.theHead.setRotationPoint(0.0F, -4.0F + var1, 0.0F);
         this.ears = new Cuboid(12, 10);
-        this.ears.method_1818(-1.5F, -4.0F, 0.0F, 3, 1, 0, 0.0F);
+        this.ears.method_1818(-1.5F, 4.0F, 0.0F, 3, 1, 0, 0.0F);
         this.ears.setRotationPoint(0.0F, -4.0F + var1, 0.0F);
         this.theBody = new Cuboid(0, 6);
-        this.theBody.method_1818(-1.5F, -4.0F, -1.5F, 3, 5, 3, 0.0F);
+        this.theBody.method_1818(-1.5F, 4.0F, -1.5F, 3, 5, 3, 0.0F);
         this.theBody.setRotationPoint(0.0F, 0.0F + var1, 0.0F);
         this.leftWing = new Cuboid(12, 0);
-        this.leftWing.method_1818(0.0F, -4.0F, 0.0F, 7, 5, 0, 0.0F);
+        this.leftWing.method_1818(0.0F, 4.0F, 0.0F, 7, 5, 0, 0.0F);
         this.leftWing.setRotationPoint(1.5F, 0.0F + var1, 0.0F);
         this.rightWing = new Cuboid(12, 5);
-        this.rightWing.method_1818(-7.0F, -4.0F, 0.0F, 7, 5, 0, 0.0F);
+        this.rightWing.method_1818(-7.0F, 4.0F, 0.0F, 7, 5, 0, 0.0F);
         this.rightWing.setRotationPoint(-1.5F, 0.0F + var1, 0.0F);
     }
 

--- a/src/main/java/dev/adventurecraft/awakening/script/Script.java
+++ b/src/main/java/dev/adventurecraft/awakening/script/Script.java
@@ -138,8 +138,11 @@ public class Script {
         return var1;
     }
 
-    public void setNewScope(Scriptable pScope) {
+    public void setNewCurScope(Scriptable pScope) {
         this.curScope = pScope;
+    }
+    public Scriptable getCurScope() {
+        return this.curScope;
     }
 
     public Object runScript(org.mozilla.javascript.Script script, Scriptable scope) {

--- a/src/main/java/dev/adventurecraft/awakening/script/ScriptEntityLiving.java
+++ b/src/main/java/dev/adventurecraft/awakening/script/ScriptEntityLiving.java
@@ -16,6 +16,10 @@ public class ScriptEntityLiving extends ScriptEntity {
         this.entityLiving = entity;
     }
 
+    public boolean isTouchingWater(){
+        return entityLiving.isTouchingWater();
+    }
+
     public void playLivingSound() {
         this.entityLiving.method_918();
     }


### PR DESCRIPTION
This Pull request contains....
- A fix for github issue #4 where trigger blocks had no collision outside of debug mode so that you could e.g. open chests through them.
- A fix for github issue #5 so that you can open every AC block with the hand now
- A fix for github issue #65 where triggerAreas weren't reset correctly, if the player died inside a trigger block and respawned before it's deathtime reached 20 (aka 1 second)
- A fix for github issue #79 so that you can place other blocks on trigger blocks now (Mouse and hand still access the Triggerblock screen)
- A fix for trigger blocks without selection, which prevented other directly connected triggerblocks with a valid selection from reseting their triggerArea (Lead to the same problem as in github issue #65)
- A fix for the attackingDamage fix, which had another scope issue with normal sword + scripts. This fix reassigns the previous scope after the onAttacked script got executed to prevent any other scope issues afterwards.
- Repositioned the bat model so that the hitbox is now (finally) correct and not below the model
- Little accessibility additions:
  - added itemUseDelay for custom items to be configurable in the item.txt instead of being hardcoded to 1
  - added isTouchingWater() method to EntityLivingScript which isway more accurate to determine if ent is in water (isInsideOfWater() only is true, if the mob is under water. isTouchingWater really gets, if the entity is touching it!)

Little note: Sorry that this has so many commits. Got kinda lost while doing some stuff here and some stuff there....
Another little note: Don't know how to get the previous commits with getMusic() etc. out of this. Hopefully that's no problem for the pull request. In case of any questions feel free to get back to me :)