### PR TITLE
Additional fixes (small adjustments...)

### DIFF
--- a/src/main/java/dev/adventurecraft/awakening/common/ServerCommands.java
+++ b/src/main/java/dev/adventurecraft/awakening/common/ServerCommands.java
@@ -209,7 +209,7 @@ public class ServerCommands {
                 if (entity instanceof LivingEntity && !(entity instanceof PlayerEntity)) {
                     mobCount++;
                     if (!entity.removed) {
-                        entity.removed = true;
+                        entity.remove();
                         count++;
                     }
                 }

--- a/src/main/java/dev/adventurecraft/awakening/extension/entity/ExEntity.java
+++ b/src/main/java/dev/adventurecraft/awakening/extension/entity/ExEntity.java
@@ -5,6 +5,10 @@ import net.minecraft.util.math.Vec3d;
 
 public interface ExEntity extends AC_IMultiAttackEntity {
 
+    void setCanGetFallDamage(boolean arg);
+
+    boolean getCanGetFallDamage();
+
     Vec3d getRotation(float deltaTime);
 
     void setRotation(double x, double y, double z);

--- a/src/main/java/dev/adventurecraft/awakening/mixin/client/MixinMinecraft.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/client/MixinMinecraft.java
@@ -17,6 +17,7 @@ import dev.adventurecraft.awakening.extension.entity.player.ExPlayerEntity;
 import dev.adventurecraft.awakening.extension.inventory.ExPlayerInventory;
 import dev.adventurecraft.awakening.extension.util.ExProgressListener;
 import dev.adventurecraft.awakening.extension.world.ExWorld;
+import dev.adventurecraft.awakening.extension.world.ExWorldProperties;
 import dev.adventurecraft.awakening.script.ScriptEntity;
 import dev.adventurecraft.awakening.script.ScriptItem;
 import dev.adventurecraft.awakening.script.ScriptVec3;
@@ -561,6 +562,15 @@ public abstract class MixinMinecraft implements ExMinecraft {
                 int chunkX = MathHelper.floor((float) ((int) this.player.x)) >> 4;
                 int chunkZ = MathHelper.floor((float) ((int) this.player.z)) >> 4;
                 chunkCache.method_1242(chunkX, chunkZ);
+            }
+            // Bed safety leave
+            if(this.player.isLyingOnBed() && this.player.getSleepTimer()>= 100)
+            {
+                if(((ExWorldProperties) this.world.properties).getTimeRate()==0){
+                    this.player.getOutOfBed(true,false,false);
+                } else {
+                    ((ExWorld) this.world).setTimeOfDay(10000);
+                }
             }
         }
 

--- a/src/main/java/dev/adventurecraft/awakening/mixin/client/render/MixinGameRenderer.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/client/render/MixinGameRenderer.java
@@ -6,6 +6,7 @@ import dev.adventurecraft.awakening.client.options.Config;
 import dev.adventurecraft.awakening.client.options.ConnectedGrassOption;
 import dev.adventurecraft.awakening.common.*;
 import dev.adventurecraft.awakening.extension.client.ExMinecraft;
+import dev.adventurecraft.awakening.extension.client.gui.screen.ExScreen;
 import dev.adventurecraft.awakening.extension.client.options.ExGameOptions;
 import dev.adventurecraft.awakening.extension.client.render.ExGameRenderer;
 import dev.adventurecraft.awakening.extension.client.render.ExHeldItemRenderer;
@@ -119,7 +120,7 @@ public abstract class MixinGameRenderer implements ExGameRenderer {
         target = "Lnet/minecraft/entity/LivingEntity;health:I",
         shift = At.Shift.BEFORE))
     private void handleZoom(float var1, CallbackInfoReturnable<Float> cir) {
-        if (Keyboard.isKeyDown(((ExGameOptions) this.client.options).ofKeyBindZoom().key)) {
+        if (Keyboard.isKeyDown(((ExGameOptions) this.client.options).ofKeyBindZoom().key) && ((ExScreen)this.client.currentScreen) == null) {
             if (!this.zoomMode) {
                 this.zoomMode = true;
                 this.client.options.cinematicMode = true;

--- a/src/main/java/dev/adventurecraft/awakening/mixin/entity/MixinLivingEntity.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/entity/MixinLivingEntity.java
@@ -549,6 +549,7 @@ public abstract class MixinLivingEntity extends MixinEntity implements ExLivingE
         tag.put("randomLookVelocity", this.randomLookVelocity);
         tag.put("randomLookRate", this.randomLookRate);
         tag.put("randomLookRateVariation", this.randomLookRateVariation);
+        tag.put("canGetFallDamage", this.canGetFallDamage);
     }
 
     @Inject(method = "readAdditional", at = @At("TAIL"))
@@ -584,6 +585,10 @@ public abstract class MixinLivingEntity extends MixinEntity implements ExLivingE
 
         if (tag.containsKey("randomLookRateVariation")) {
             this.randomLookRateVariation = tag.getInt("randomLookRateVariation");
+        }
+
+        if (tag.containsKey("canGetFallDamage")) {
+            this.canGetFallDamage = tag.getBoolean("canGetFallDamage");
         }
     }
 

--- a/src/main/java/dev/adventurecraft/awakening/mixin/entity/MixinLivingEntity.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/entity/MixinLivingEntity.java
@@ -98,6 +98,10 @@ public abstract class MixinLivingEntity extends MixinEntity implements ExLivingE
     @Shadow
     protected int field_1034;
 
+    public boolean canGetFallDamage = true;
+    public void setCanGetFallDamage(boolean arg){this.canGetFallDamage = arg;};
+    public boolean getCanGetFallDamage(){return this.canGetFallDamage;};
+
     protected int maxHealth = 10;
     @Unique
     private ItemStack ac$heldItem;
@@ -351,6 +355,10 @@ public abstract class MixinLivingEntity extends MixinEntity implements ExLivingE
 
     @Overwrite
     public void handleFallDamage(float var1) {
+        if(!this.canGetFallDamage) {
+            return;
+        }
+
         if (this.handleFlying()) {
             return;
         }

--- a/src/main/java/dev/adventurecraft/awakening/mixin/entity/decoration/painting/MixinPaintingEntity.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/entity/decoration/painting/MixinPaintingEntity.java
@@ -1,10 +1,12 @@
 package dev.adventurecraft.awakening.mixin.entity.decoration.painting;
 
+import dev.adventurecraft.awakening.common.AC_DebugMode;
 import net.minecraft.entity.decoration.painting.PaintingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PaintingEntity.class)
 public abstract class MixinPaintingEntity {
@@ -12,5 +14,12 @@ public abstract class MixinPaintingEntity {
     @Inject(method = "tick", at = @At("HEAD"), cancellable = true)
     private void disableTick(CallbackInfo ci) {
         ci.cancel();
+    }
+
+    // Only breakable in debug mode!
+    @Inject(method = "damage", at = @At("HEAD"), cancellable = true)
+    private void disableHurt(CallbackInfoReturnable ci) {
+        if(!AC_DebugMode.active)
+            ci.cancel();
     }
 }

--- a/src/main/java/dev/adventurecraft/awakening/script/ScriptEffect.java
+++ b/src/main/java/dev/adventurecraft/awakening/script/ScriptEffect.java
@@ -127,4 +127,8 @@ public class ScriptEffect {
     public void cancelCutscene() {
         ((ExMinecraft) Minecraft.instance).setCameraActive(false);
     }
+
+    public boolean getIsCameraActive(){
+        return ((ExMinecraft) Minecraft.instance).isCameraActive();
+    }
 }

--- a/src/main/java/dev/adventurecraft/awakening/script/ScriptEntity.java
+++ b/src/main/java/dev/adventurecraft/awakening/script/ScriptEntity.java
@@ -45,6 +45,12 @@ public class ScriptEntity {
         return new ScriptEntity(entity);
     }
 
+    public void setCanGetFallDamage(boolean arg){
+        ((ExEntity)this.entity).setCanGetFallDamage(arg);
+    }
+    public boolean getCanGetFallDamage(){
+        return ((ExEntity)this.entity).getCanGetFallDamage();
+    }
     public int getEntityID() {
         return this.entity.entityId;
     }


### PR DESCRIPTION
This little pull request contains...
- Fixed issue #76 -> Optifine zoom only works in screen null
- Paintings are now only destroyable in debug mode
- added access to effect.getIsCameraActive() to get, if a camera cutscene is currently running
- /removemobs now calls scripted mob OnDeath scripts (didn't do so before)
- Removed softlock in bed by getting player out of bed, if timerate == 0
- Falldamage is now configurable with functions getCanGetFallDamage() and setCanGetFallDamage(boolean) for each LivingEntity