### PR TITLE
Add missing methods on ScriptModel*

### DIFF
--- a/src/main/java/dev/adventurecraft/awakening/extension/client/model/ExCuboid.java
+++ b/src/main/java/dev/adventurecraft/awakening/extension/client/model/ExCuboid.java
@@ -10,6 +10,8 @@ public interface ExCuboid {
 
     void setTHeight(int value);
 
+    boolean canRender();
+
     void render();
 
     void translateTo(Matrix4f transform);

--- a/src/main/java/dev/adventurecraft/awakening/mixin/client/model/MixinCuboid.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/client/model/MixinCuboid.java
@@ -103,12 +103,22 @@ public abstract class MixinCuboid implements ExCuboid {
         int h = this.tHeight;
 
         this.polygons = new Polygon[6];
-        this.polygons[0] = ExTexturedQuad.create(new Vertex[]{this.vertices[5], this.vertices[1], this.vertices[2], this.vertices[6]}, this.xTexOffs + length + width + length, this.yTexOffs + length + height, this.xTexOffs + length + width, this.yTexOffs + length, w, h);
-        this.polygons[1] = ExTexturedQuad.create(new Vertex[]{this.vertices[0], this.vertices[4], this.vertices[7], this.vertices[3]}, this.xTexOffs + length, this.yTexOffs + length + height, this.xTexOffs, this.yTexOffs + length, w, h);
-        this.polygons[2] = ExTexturedQuad.create(new Vertex[]{this.vertices[5], this.vertices[4], this.vertices[0], this.vertices[1]}, this.xTexOffs + length + width + width, this.yTexOffs, this.xTexOffs + length + width, this.yTexOffs + length, w, h);
-        this.polygons[3] = ExTexturedQuad.create(new Vertex[]{this.vertices[2], this.vertices[3], this.vertices[7], this.vertices[6]}, this.xTexOffs + length + width, this.yTexOffs, this.xTexOffs + length, this.yTexOffs + length, w, h);
-        this.polygons[4] = ExTexturedQuad.create(new Vertex[]{this.vertices[1], this.vertices[0], this.vertices[3], this.vertices[2]}, this.xTexOffs + length + width + length + width, this.yTexOffs + length + height, this.xTexOffs + length + width + length, this.yTexOffs + length, w, h);
-        this.polygons[5] = ExTexturedQuad.create(new Vertex[]{this.vertices[4], this.vertices[5], this.vertices[6], this.vertices[7]}, this.xTexOffs + length + width, this.yTexOffs + length + height, this.xTexOffs + length, this.yTexOffs + length, w, h);
+        this.polygons[0] = ExTexturedQuad.create(new Vertex[]{this.vertices[5], this.vertices[1], this.vertices[2], this.vertices[6]},
+            this.xTexOffs + length + width + length,
+            this.yTexOffs + length + height, this.xTexOffs + length + width, this.yTexOffs + length, w, h);
+        this.polygons[1] = ExTexturedQuad.create(new Vertex[]{this.vertices[0], this.vertices[4], this.vertices[7], this.vertices[3]},
+            this.xTexOffs + length, this.yTexOffs + length + height, this.xTexOffs, this.yTexOffs + length, w, h);
+        this.polygons[2] = ExTexturedQuad.create(new Vertex[]{this.vertices[5], this.vertices[4], this.vertices[0], this.vertices[1]},
+            this.xTexOffs + length + width + width, this.yTexOffs,
+            this.xTexOffs + length + width, this.yTexOffs + length, w, h);
+        this.polygons[3] = ExTexturedQuad.create(new Vertex[]{this.vertices[2], this.vertices[3], this.vertices[7], this.vertices[6]},
+            this.xTexOffs + length + width, this.yTexOffs, this.xTexOffs + length, this.yTexOffs + length, w, h);
+        this.polygons[4] = ExTexturedQuad.create(new Vertex[]{this.vertices[1], this.vertices[0], this.vertices[3], this.vertices[2]},
+            this.xTexOffs + length + width + length + width,
+            this.yTexOffs + length + height, this.xTexOffs + length + width + length, this.yTexOffs + length, w, h);
+        this.polygons[5] = ExTexturedQuad.create(new Vertex[]{this.vertices[4], this.vertices[5], this.vertices[6], this.vertices[7]},
+            this.xTexOffs + length + width,
+            this.yTexOffs + length + height, this.xTexOffs + length, this.yTexOffs + length, w, h);
 
         if (this.mirror) {
             for (Polygon face : this.polygons) {
@@ -127,12 +137,19 @@ public abstract class MixinCuboid implements ExCuboid {
         this.tHeight = value;
     }
 
-    @Override
-    public void render() {
+    public @Override boolean canRender() {
         if (this.neverRender) {
-            return;
+            return false;
         }
         if (!this.visible) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void render() {
+        if (!this.canRender()) {
             return;
         }
         if (!this.compiled) {

--- a/src/main/java/dev/adventurecraft/awakening/script/ScriptModel.java
+++ b/src/main/java/dev/adventurecraft/awakening/script/ScriptModel.java
@@ -18,14 +18,6 @@ public class ScriptModel extends ScriptModelBase {
         this.textureHeight = height;
     }
 
-    public void setBrightness(float brightness) {
-        this.colorRed = this.colorGreen = this.colorBlue = Math.min(brightness, 1.0F);
-    }
-
-    public void setBrightness(int brightness) {
-        setBrightness(Math.max(brightness, 255) / 256.0F);
-    }
-
     //Old method
     public void addBox(
         String boxName,
@@ -62,57 +54,6 @@ public class ScriptModel extends ScriptModelBase {
         ((ExCuboid) cuboid).setTHeight(this.textureHeight);
         ((ExCuboid) cuboid).addBoxInverted(offsetX, offsetY, offsetZ, width, height, length, scale);
         this.boxes.add(cuboid);
-    }
-
-    public void moveTo(double x, double y, double z) {
-        this.x = x;
-        this.y = y;
-        this.z = z;
-    }
-
-    public void moveBy(double x, double y, double z) {
-        float yaw = MathF.toRadians(this.yaw);
-        float pitch = MathF.toRadians(this.pitch);
-        float roll = MathF.toRadians(this.roll);
-
-        float sinYaw = MathF.sin(yaw);
-        float cosYaw = MathF.cos(yaw);
-        double tempY = x * cosYaw + z * sinYaw;
-        z = z * cosYaw - x * sinYaw;
-        x = tempY;
-
-        float sinPitch = MathF.sin(pitch);
-        float cosPitch = MathF.cos(pitch);
-        tempY = z * cosPitch + y * sinPitch;
-        y = y * cosPitch - z * sinPitch;
-        z = tempY;
-
-        float sinRoll = MathF.sin(roll);
-        float cosRoll = MathF.cos(roll);
-        tempY = y * cosRoll + x * sinRoll;
-        x = x * cosRoll - y * sinRoll;
-
-        this.x += x;
-        this.y += tempY;
-        this.z += z;
-    }
-
-    public void setRotation(float yaw, float pitch, float roll) {
-        this.prevYaw = this.yaw = yaw;
-        this.prevPitch = this.pitch = pitch;
-        this.prevRoll = this.roll = roll;
-    }
-
-    public void rotateTo(float yaw, float pitch, float roll) {
-        this.yaw = yaw;
-        this.pitch = pitch;
-        this.roll = roll;
-    }
-
-    public void rotateBy(float yaw, float pitch, float roll) {
-        this.yaw += yaw;
-        this.pitch += pitch;
-        this.roll += roll;
     }
 
     @Override

--- a/src/main/java/dev/adventurecraft/awakening/script/ScriptModelBase.java
+++ b/src/main/java/dev/adventurecraft/awakening/script/ScriptModelBase.java
@@ -149,20 +149,85 @@ public abstract class ScriptModelBase {
         this.colorRed = this.colorGreen = this.colorBlue = brightness;
     }
 
+    public void setBrightness(int brightness) {
+        this.setBrightness(Math.max(brightness, 255) / 256.0F);
+    }
+
     public void setPosition(double x, double y, double z) {
-        this.prevX = this.x = x;
-        this.prevY = this.y = y;
-        this.prevZ = this.z = z;
+        this.moveTo(x, y, z);
+        this.prevX = this.x;
+        this.prevY = this.y;
+        this.prevZ = this.z;
     }
 
     public void setPosition(ScriptVec3 vec) {
-        this.prevX = this.x = vec.x;
-        this.prevY = this.y = vec.y;
-        this.prevZ = this.z = vec.z;
+        this.setPosition(vec.x, vec.y, vec.z);
     }
 
     public ScriptVec3 getPosition() {
         return new ScriptVec3(x, y, z);
+    }
+
+    public void moveTo(double x, double y, double z) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    public void moveBy(double x, double y, double z) {
+        float yaw = MathF.toRadians(this.yaw);
+        float pitch = MathF.toRadians(this.pitch);
+        float roll = MathF.toRadians(this.roll);
+
+        float sinYaw = MathF.sin(yaw);
+        float cosYaw = MathF.cos(yaw);
+        double tempY = x * cosYaw + z * sinYaw;
+        z = z * cosYaw - x * sinYaw;
+        x = tempY;
+
+        float sinPitch = MathF.sin(pitch);
+        float cosPitch = MathF.cos(pitch);
+        tempY = z * cosPitch + y * sinPitch;
+        y = y * cosPitch - z * sinPitch;
+        z = tempY;
+
+        float sinRoll = MathF.sin(roll);
+        float cosRoll = MathF.cos(roll);
+        tempY = y * cosRoll + x * sinRoll;
+        x = x * cosRoll - y * sinRoll;
+
+        x += this.x;
+        tempY += this.y;
+        z += this.z;
+        this.moveTo(x, tempY, z);
+    }
+
+    public void rotateTo(float yaw, float pitch, float roll) {
+        this.yaw = yaw;
+        this.pitch = pitch;
+        this.roll = roll;
+    }
+
+    public void rotateBy(float yaw, float pitch, float roll) {
+        yaw += this.yaw;
+        pitch += this.pitch;
+        roll += this.roll;
+        this.rotateTo(yaw, pitch, roll);
+    }
+
+    public void setRotation(float yaw, float pitch, float roll) {
+        this.rotateTo(yaw, pitch, roll);
+        this.prevYaw = this.yaw;
+        this.prevPitch = this.pitch;
+        this.prevRoll = this.roll;
+    }
+
+    public void setRotation(ScriptVec3 vec) {
+        this.setRotation((float) vec.x, (float) vec.y, (float) vec.z);
+    }
+
+    public ScriptVec3 getRotation() {
+        return new ScriptVec3(this.yaw, this.pitch, this.roll);
     }
 
     public void setAlpha(float alpha) {

--- a/src/main/java/dev/adventurecraft/awakening/script/ScriptModelBase.java
+++ b/src/main/java/dev/adventurecraft/awakening/script/ScriptModelBase.java
@@ -64,9 +64,9 @@ public abstract class ScriptModelBase {
             return;
         }
         Level world = Minecraft.instance.level;
-        Textures var3 = Minecraft.instance.textures;
+        Textures texMan = Minecraft.instance.textures;
         if (this.texture != null && !this.texture.isEmpty()) {
-            var3.bind(var3.loadTexture(this.texture));
+            texMan.bind(texMan.loadTexture(this.texture));
         }
 
         var localMat = new Matrix4f();
@@ -79,9 +79,11 @@ public abstract class ScriptModelBase {
                     this.setBrightness(this.attachedTo.entity.getBrightness(partialTick));
                 }
                 break;
+
             case 2:
                 // usage for custom RGB Values
                 break;
+
             case 3:
                 // use the lightning value of the attached model
                 if (this.modelAttachment != null) {
@@ -90,6 +92,7 @@ public abstract class ScriptModelBase {
                     this.colorBlue = this.modelAttachment.colorBlue;
                 }
                 break;
+
             default:
                 // Default lightning values
                 var vr = Matrix4f.transform(localMat, new Vector3f(), new Vector3f());
@@ -108,17 +111,23 @@ public abstract class ScriptModelBase {
             GL11.glColor3f(r, g, b);
         }
 
-        var cuboidMat = Matrix4f.mul(transform, localMat, localMat);
+        Matrix4f.mul(transform, localMat, localMat);
         try (var stack = MemoryStack.stackPush()) {
             var matBuf = stack.mallocFloat(16);
 
+            var mat = new Matrix4f();
             for (ModelPart cuboid : this.boxes) {
-                var mat = new Matrix4f(cuboidMat);
-                ((ExCuboid) cuboid).translateTo(mat);
+                var exCuboid = (ExCuboid) cuboid;
+                if (!exCuboid.canRender()) {
+                    continue;
+                }
+
+                mat.load(localMat);
+                exCuboid.translateTo(mat);
 
                 mat.store(matBuf);
                 GL11.glLoadMatrixf(matBuf.flip());
-                ((ExCuboid) cuboid).render();
+                exCuboid.render();
             }
         }
 

--- a/src/main/java/dev/adventurecraft/awakening/script/ScriptModelBlockbench.java
+++ b/src/main/java/dev/adventurecraft/awakening/script/ScriptModelBlockbench.java
@@ -87,6 +87,18 @@ public class ScriptModelBlockbench extends ScriptModelBase {
         this.boxes.add(cuboid);
     }
 
+    public void addBoxExpanded(
+        int width, int height, int length,
+        int textureOffsetX, int textureOffsetY, float inflate) {
+        this.setSize(width, height, length);
+
+        var cuboid = new ModelPart(textureOffsetX, textureOffsetY);
+        ((ExCuboid) cuboid).setTWidth(this.textureWidth);
+        ((ExCuboid) cuboid).setTHeight(this.textureHeight);
+        ((ExCuboid) cuboid).addBoxInverted(0, 0, 0, width, height, length, inflate);
+        this.boxes.add(cuboid);
+    }
+
     public void setRotation(float yaw, float pitch, float roll) {
         this.prevRoll = this.roll = roll;
         this.prevPitch = this.pitch = -pitch;
@@ -144,6 +156,67 @@ public class ScriptModelBlockbench extends ScriptModelBase {
     public ScriptVec3 getPivot() {
         return new ScriptVec3(this.pivotX, this.pivotY, this.pivotZ);
     }
+
+    public void setBrightness(float brightness) {
+        this.colorRed = this.colorGreen = this.colorBlue = Math.min(brightness, 1.0F);
+    }
+
+    public void setBrightness(int brightness) {
+        setBrightness(Math.max(brightness, 255) / 256.0F);
+    }
+
+    public void moveTo(double x, double y, double z) {
+        this.prevX = this.x = x;
+        this.prevY = this.y = y;
+        this.prevZ = this.z = z;
+    }
+
+    public void moveBy(double x, double y, double z) {
+        float yaw = MathF.toRadians(this.yaw);
+        float pitch = MathF.toRadians(this.pitch);
+        float roll = MathF.toRadians(this.roll);
+
+        float sinYaw = MathF.sin(yaw);
+        float cosYaw = MathF.cos(yaw);
+        double tempY = x * cosYaw + z * sinYaw;
+        z = z * cosYaw - x * sinYaw;
+        x = tempY;
+
+        float sinPitch = MathF.sin(pitch);
+        float cosPitch = MathF.cos(pitch);
+        tempY = z * cosPitch + y * sinPitch;
+        y = y * cosPitch - z * sinPitch;
+        z = tempY;
+
+        float sinRoll = MathF.sin(roll);
+        float cosRoll = MathF.cos(roll);
+        tempY = y * cosRoll + x * sinRoll;
+        x = x * cosRoll - y * sinRoll;
+
+        this.prevX = this.x += x;
+        this.prevY = this.y += tempY;
+        this.prevZ = this.z += z;
+    }
+
+
+    public void rotateTo(float yaw, float pitch, float roll) {
+        this.prevYaw = this.yaw = -yaw;
+        this.prevPitch = this.pitch = -pitch;
+        this.prevRoll = this.roll = roll;
+    }
+
+
+    public void rotateBy(float yaw, float pitch, float roll) {
+        this.yaw -= yaw;
+        this.pitch -= pitch;
+        this.roll += roll;
+
+        this.prevYaw = this.yaw;
+        this.prevPitch = this.pitch;
+        this.prevRoll = this.roll;
+    }
+
+
 }
 
 

--- a/src/main/java/dev/adventurecraft/awakening/script/ScriptModelBlockbench.java
+++ b/src/main/java/dev/adventurecraft/awakening/script/ScriptModelBlockbench.java
@@ -2,12 +2,7 @@ package dev.adventurecraft.awakening.script;
 
 import dev.adventurecraft.awakening.extension.client.model.ExCuboid;
 import dev.adventurecraft.awakening.util.MathF;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.geom.ModelPart;
-import net.minecraft.client.renderer.Textures;
-import net.minecraft.world.level.Level;
-import org.lwjgl.opengl.GL11;
-import org.lwjgl.system.MemoryStack;
 import org.lwjgl.util.vector.Matrix4f;
 
 public class ScriptModelBlockbench extends ScriptModelBase {
@@ -55,21 +50,23 @@ public class ScriptModelBlockbench extends ScriptModelBase {
         float deg = MathF.toRadians(partialTick);
         float invDeg = MathF.toRadians(invDelta);
         matrix.rotateZ(-(deg * this.roll + invDeg * this.prevRoll));
-        matrix.rotateY(-(deg * this.pitch + invDeg * this.prevPitch));
-        matrix.rotateX(deg * this.yaw + invDeg * this.prevYaw);
+        matrix.rotateY(-(deg * -this.pitch + invDeg * -this.prevPitch));
+        matrix.rotateX(deg * -this.yaw + invDeg * -this.prevYaw);
 
         // Apply scaling
         matrix.scale(this.scaleX, this.scaleY, this.scaleZ);
 
         // Move Object to intended Position
         matrix.translate(
-            (float) (-x - this.sizeX + this.pivotX) * pxSize,
-            (float) (y - this.pivotY) * pxSize,
-            (float) (-z - this.sizeZ + this.pivotZ) * pxSize);
+            (float) ((-x - this.sizeX + this.pivotX) * pxSize),
+            (float) ((y - this.pivotY) * pxSize),
+            (float) ((-z - this.sizeZ + this.pivotZ) * pxSize));
     }
 
     @Override
     protected void update() {
+        super.update();
+
         this.prevScaleX = this.scaleX;
         this.prevScaleY = this.scaleY;
         this.prevScaleZ = this.scaleZ;
@@ -99,32 +96,24 @@ public class ScriptModelBlockbench extends ScriptModelBase {
         this.boxes.add(cuboid);
     }
 
-    public void setRotation(float yaw, float pitch, float roll) {
-        this.prevRoll = this.roll = roll;
-        this.prevPitch = this.pitch = -pitch;
-        this.prevYaw = this.yaw = -yaw;
+    public void scaleTo(float x, float y, float z) {
+        this.scaleX = x;
+        this.scaleY = y;
+        this.scaleZ = z;
     }
 
-    public void setRotation(ScriptVec3 vec) {
-        this.prevRoll = this.roll = (float) vec.z;
-        this.prevPitch = this.pitch = -(float) vec.y;
-        this.prevYaw = this.yaw = -(float) vec.x;
+    public void scaleBy(float x, float y, float z) {
+        x += this.scaleX;
+        y += this.scaleY;
+        z += this.scaleZ;
+        this.scaleTo(x, y, z);
     }
 
-    public ScriptVec3 getRotation() {
-        return new ScriptVec3(-this.yaw, -this.pitch, this.roll);
-    }
-
-    public void scaleBy(float factorX, float factorY, float factorZ) {
-        this.scaleX += factorX;
-        this.scaleY += factorY;
-        this.scaleZ += factorZ;
-    }
-
-    public void setScale(float scaleX, float scaleY, float scaleZ) {
-        this.scaleX = scaleX;
-        this.scaleY = scaleY;
-        this.scaleZ = scaleZ;
+    public void setScale(float x, float y, float z) {
+        this.scaleTo(x, y, z);
+        this.prevScaleX = this.scaleX;
+        this.prevScaleY = this.scaleY;
+        this.prevScaleZ = this.scaleZ;
     }
 
     public ScriptVec3 getScale() {
@@ -148,75 +137,12 @@ public class ScriptModelBlockbench extends ScriptModelBase {
     }
 
     public void setPivot(ScriptVec3 vec) {
-        this.pivotX = (float) vec.x;
-        this.pivotY = (float) vec.y;
-        this.pivotZ = (float) vec.z;
+        this.setPivot((float) vec.x, (float) vec.y, (float) vec.z);
     }
 
     public ScriptVec3 getPivot() {
         return new ScriptVec3(this.pivotX, this.pivotY, this.pivotZ);
     }
-
-    public void setBrightness(float brightness) {
-        this.colorRed = this.colorGreen = this.colorBlue = Math.min(brightness, 1.0F);
-    }
-
-    public void setBrightness(int brightness) {
-        setBrightness(Math.max(brightness, 255) / 256.0F);
-    }
-
-    public void moveTo(double x, double y, double z) {
-        this.prevX = this.x = x;
-        this.prevY = this.y = y;
-        this.prevZ = this.z = z;
-    }
-
-    public void moveBy(double x, double y, double z) {
-        float yaw = MathF.toRadians(this.yaw);
-        float pitch = MathF.toRadians(this.pitch);
-        float roll = MathF.toRadians(this.roll);
-
-        float sinYaw = MathF.sin(yaw);
-        float cosYaw = MathF.cos(yaw);
-        double tempY = x * cosYaw + z * sinYaw;
-        z = z * cosYaw - x * sinYaw;
-        x = tempY;
-
-        float sinPitch = MathF.sin(pitch);
-        float cosPitch = MathF.cos(pitch);
-        tempY = z * cosPitch + y * sinPitch;
-        y = y * cosPitch - z * sinPitch;
-        z = tempY;
-
-        float sinRoll = MathF.sin(roll);
-        float cosRoll = MathF.cos(roll);
-        tempY = y * cosRoll + x * sinRoll;
-        x = x * cosRoll - y * sinRoll;
-
-        this.prevX = this.x += x;
-        this.prevY = this.y += tempY;
-        this.prevZ = this.z += z;
-    }
-
-
-    public void rotateTo(float yaw, float pitch, float roll) {
-        this.prevYaw = this.yaw = -yaw;
-        this.prevPitch = this.pitch = -pitch;
-        this.prevRoll = this.roll = roll;
-    }
-
-
-    public void rotateBy(float yaw, float pitch, float roll) {
-        this.yaw -= yaw;
-        this.pitch -= pitch;
-        this.roll += roll;
-
-        this.prevYaw = this.yaw;
-        this.prevPitch = this.pitch;
-        this.prevRoll = this.roll;
-    }
-
-
 }
 
 


### PR DESCRIPTION
Forgot methods: addBoxExpanded -> Which enables the use of inflate within blockbench

Brightness methods

and moveTo / moveBy and rotateTo / rotateBy which were slightly adjusted to also update prev values (had weird flicker issues otherwise)