### PR TITLE
Fix Cake consume

### DIFF
--- a/src/main/java/dev/adventurecraft/awakening/mixin/world/MixinCakeTile.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/world/MixinCakeTile.java
@@ -1,0 +1,27 @@
+package dev.adventurecraft.awakening.mixin.world;
+
+import dev.adventurecraft.awakening.extension.entity.ExLivingEntity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.tile.CakeTile;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+
+@Mixin(CakeTile.class)
+public abstract class MixinCakeTile {
+
+    @Overwrite
+    private void eat(Level level, int x, int y, int z, Player player) {
+        if (player.health < ((ExLivingEntity)player).getMaxHealth()) {
+            player.heal(3);
+            int var6 = level.getData(x, y, z) + 1;
+            if (var6 >= 6) {
+                level.setTile(x, y, z, 0);
+            } else {
+                level.setData(x, y, z, var6);
+                level.setTileDirty(x, y, z);
+            }
+        }
+
+    }
+}

--- a/src/main/resources/adventurecraft.mixins.json
+++ b/src/main/resources/adventurecraft.mixins.json
@@ -132,6 +132,7 @@
     "item.MixinSwordItem",
     "util.MixinMth",
     "util.io.MixinCompoundTag",
+    "world.MixinCakeTile",
     "world.MixinWorld",
     "world.MixinWorldManager",
     "world.MixinWorldPopulationRegion",


### PR DESCRIPTION
Fixes cake consume. The previous logic was that you could always eat cake if health < 20. This changes the requirement so that you can always eat cake, if health < maxHealth.
- Fixes issue #10 