### PR TITLE
Fixes slow destroy speed, while not being on ground

### DIFF
--- a/src/main/java/dev/adventurecraft/awakening/mixin/entity/player/MixinPlayerEntity.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/entity/player/MixinPlayerEntity.java
@@ -430,4 +430,10 @@ public abstract class MixinPlayerEntity extends MixinLivingEntity implements ExP
     public void setCloakTexture(String value) {
         this.cloakTexture = value;
     }
+
+    @Overwrite
+    public float getDestroySpeed(Tile tile) {
+        float destroySpeed = this.inventory.getDestroySpeed(tile);
+        return destroySpeed;
+    }
 }


### PR DESCRIPTION
- Fixes slow destroy speed, while player.onGround was false (in case you used /fly, jumped, jumped and used /noclip while being in air)
- Fixes issue #23 