### PR TITLE
fix runCreatedScript scope (workaround)

### DIFF
--- a/src/main/java/dev/adventurecraft/awakening/entity/AC_EntityLivingScript.java
+++ b/src/main/java/dev/adventurecraft/awakening/entity/AC_EntityLivingScript.java
@@ -172,7 +172,13 @@ public class AC_EntityLivingScript extends Mob implements IEntityPather {
 
     public void runCreatedScript() {
         if (!this.onCreated.equals("")) {
+            // Save curscope temporary
+            Scriptable tempScope = ((ExWorld) this.level).getScript().getCurScope();
+            ((ExWorld) this.level).getScript().setNewCurScope(this.scope);
+            // Run OnCreated Script
             ((ExWorld) this.level).getScriptHandler().runScript(this.onCreated, this.scope);
+            // Reset curScope afterwards! IMPORTANT for normal damage scripts
+            ((ExWorld) this.level).getScript().setNewCurScope(tempScope);
         }
     }
 


### PR DESCRIPTION
- Fixes possibility of being in wrong scope when setting OnCreated script to mob via script