### PR TITLE
Fix: Remember current slots

### DIFF
--- a/src/main/java/dev/adventurecraft/awakening/extension/inventory/ExPlayerInventory.java
+++ b/src/main/java/dev/adventurecraft/awakening/extension/inventory/ExPlayerInventory.java
@@ -6,9 +6,13 @@ public interface ExPlayerInventory {
 
     boolean consumeItemAmount(int var1, int var2, int var3);
 
-    int getOffhandItem();
+    int getOffhandSlot();
 
-    void setOffhandItem(int value);
+    void setOffhandSlot(int value);
+
+    int getMainhandSlot();
+
+    void setMainhandSlot(int value);
 
     ItemInstance getOffhandItemStack();
 

--- a/src/main/java/dev/adventurecraft/awakening/extension/inventory/ExPlayerInventory.java
+++ b/src/main/java/dev/adventurecraft/awakening/extension/inventory/ExPlayerInventory.java
@@ -17,4 +17,6 @@ public interface ExPlayerInventory {
     ItemInstance getOffhandItemStack();
 
     void swapOffhandWithMain();
+
+    void swapOffhandWithMainSlot();
 }

--- a/src/main/java/dev/adventurecraft/awakening/extension/world/ExWorldProperties.java
+++ b/src/main/java/dev/adventurecraft/awakening/extension/world/ExWorldProperties.java
@@ -138,4 +138,12 @@ public interface ExWorldProperties {
     void setCanUseBonemeal(boolean arg);
 
     boolean getCanUseBonemeal();
+
+    int getMainhandSlot();
+
+    void setMainhandSlot(int arg);
+
+    int getOffhandSlot();
+
+    void setOffhandSlot(int arg);
 }

--- a/src/main/java/dev/adventurecraft/awakening/mixin/client/MixinMinecraft.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/client/MixinMinecraft.java
@@ -784,16 +784,12 @@ public abstract class MixinMinecraft implements ExMinecraft {
                             this.gui.addMessage(String.format("Reach Changed to %d", AC_DebugMode.reachDistance));
                         } else {
                             if (ctrlDown) {
-                                int selectedSlot = this.player.inventory.selected;
-                                this.player.inventory.selected = ((ExPlayerInventory) this.player.inventory).getOffhandSlot();
-                                ((ExPlayerInventory) this.player.inventory).setOffhandSlot(selectedSlot);
+                                ((ExPlayerInventory)this.player.inventory).swapOffhandWithMainSlot();
                             }
 
                             this.player.inventory.swapPaint(wheelDelta);
                             if (ctrlDown) {
-                                int selectedSlot = this.player.inventory.selected;
-                                this.player.inventory.selected = ((ExPlayerInventory) this.player.inventory).getOffhandSlot();
-                                ((ExPlayerInventory) this.player.inventory).setOffhandSlot(selectedSlot);
+                                ((ExPlayerInventory)this.player.inventory).swapOffhandWithMainSlot();
                             }
 
                             if (this.options.discreteMouseScroll) {

--- a/src/main/java/dev/adventurecraft/awakening/mixin/client/MixinMinecraft.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/client/MixinMinecraft.java
@@ -784,7 +784,7 @@ public abstract class MixinMinecraft implements ExMinecraft {
                             this.gui.addMessage(String.format("Reach Changed to %d", AC_DebugMode.reachDistance));
                         } else {
                             if (ctrlDown) {
-                                ((ExPlayerInventory)this.player.inventory).swapOffhandWithMainSlot();
+                                ((ExPlayerInventory)this.player.inventory).swapOffhandWithMain();
                             }
 
                             this.player.inventory.swapPaint(wheelDelta);

--- a/src/main/java/dev/adventurecraft/awakening/mixin/client/MixinMinecraft.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/client/MixinMinecraft.java
@@ -741,17 +741,17 @@ public abstract class MixinMinecraft implements ExMinecraft {
 
                                     if (eventKey == Keyboard.KEY_1 + currentSlot) {
                                         if (!isControlPressed) {
-                                            if (currentSlot == ((ExPlayerInventory) this.player.inventory).getOffhandItem()) {
-                                                ((ExPlayerInventory) this.player.inventory).setOffhandItem(this.player.inventory.selected);
+                                            if (currentSlot == ((ExPlayerInventory) this.player.inventory).getOffhandSlot()) {
+                                                ((ExPlayerInventory) this.player.inventory).setOffhandSlot(this.player.inventory.selected);
                                             }
 
                                             this.player.inventory.selected = currentSlot;
                                         } else {
                                             if (currentSlot == this.player.inventory.selected) {
-                                                this.player.inventory.selected = ((ExPlayerInventory) this.player.inventory).getOffhandItem();
+                                                this.player.inventory.selected = ((ExPlayerInventory) this.player.inventory).getOffhandSlot();
                                             }
 
-                                            ((ExPlayerInventory) this.player.inventory).setOffhandItem(currentSlot);
+                                            ((ExPlayerInventory) this.player.inventory).setOffhandSlot(currentSlot);
                                         }
                                     }
 
@@ -785,15 +785,15 @@ public abstract class MixinMinecraft implements ExMinecraft {
                         } else {
                             if (ctrlDown) {
                                 int selectedSlot = this.player.inventory.selected;
-                                this.player.inventory.selected = ((ExPlayerInventory) this.player.inventory).getOffhandItem();
-                                ((ExPlayerInventory) this.player.inventory).setOffhandItem(selectedSlot);
+                                this.player.inventory.selected = ((ExPlayerInventory) this.player.inventory).getOffhandSlot();
+                                ((ExPlayerInventory) this.player.inventory).setOffhandSlot(selectedSlot);
                             }
 
                             this.player.inventory.swapPaint(wheelDelta);
                             if (ctrlDown) {
                                 int selectedSlot = this.player.inventory.selected;
-                                this.player.inventory.selected = ((ExPlayerInventory) this.player.inventory).getOffhandItem();
-                                ((ExPlayerInventory) this.player.inventory).setOffhandItem(selectedSlot);
+                                this.player.inventory.selected = ((ExPlayerInventory) this.player.inventory).getOffhandSlot();
+                                ((ExPlayerInventory) this.player.inventory).setOffhandSlot(selectedSlot);
                             }
 
                             if (this.options.discreteMouseScroll) {

--- a/src/main/java/dev/adventurecraft/awakening/mixin/client/gui/MixinInGameHud.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/client/gui/MixinInGameHud.java
@@ -145,7 +145,7 @@ public abstract class MixinInGameHud extends GuiComponent implements ExInGameHud
             Inventory var11 = this.minecraft.player.inventory;
             this.blitOffset = -90.0F;
             this.blit(screenWidth / 2 - 91, screenHeight - 22, 0, 0, 182, 22);
-            this.blit(screenWidth / 2 - 91 - 1 + ((ExPlayerInventory) var11).getOffhandItem() * 20, screenHeight - 22 - 1, 24, 22, 48, 22);
+            this.blit(screenWidth / 2 - 91 - 1 + ((ExPlayerInventory) var11).getOffhandSlot() * 20, screenHeight - 22 - 1, 24, 22, 48, 22);
             this.blit(screenWidth / 2 - 91 - 1 + var11.selected * 20, screenHeight - 22 - 1, 0, 22, 24, 22);
             GL11.glBindTexture(GL11.GL_TEXTURE_2D, this.minecraft.textures.loadTexture("/gui/icons.png"));
             GL11.glEnable(GL11.GL_BLEND);

--- a/src/main/java/dev/adventurecraft/awakening/mixin/inventory/MixinPlayerInventory.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/inventory/MixinPlayerInventory.java
@@ -59,6 +59,7 @@ public abstract class MixinPlayerInventory implements ExPlayerInventory {
     @Override
     public void setOffhandSlot(int value) {
         this.offhandItem = value;
+        ((ExWorldProperties)this.player.level.levelData).setOffhandSlot(this.offhandItem);
     }
 
     @Override
@@ -69,6 +70,7 @@ public abstract class MixinPlayerInventory implements ExPlayerInventory {
     @Override
     public void setMainhandSlot(int value) {
         this.selected = value;
+        ((ExWorldProperties)this.player.level.levelData).setMainhandSlot(this.selected);
     }
 
     public ItemInstance getOffhandItemStack() {
@@ -79,6 +81,16 @@ public abstract class MixinPlayerInventory implements ExPlayerInventory {
         int slot = this.selected;
         this.selected = this.offhandItem;
         this.offhandItem = slot;
+    }
+
+    // Method specifically not for the stuff that abuses swappOffhandWithMain method
+    public void swapOffhandWithMainSlot() {
+        int slot = this.selected;
+        this.selected = this.offhandItem;
+        this.offhandItem = slot;
+        // Update properties
+        ((ExWorldProperties)this.player.level.levelData).setMainhandSlot(this.selected);
+        ((ExWorldProperties)this.player.level.levelData).setOffhandSlot(this.offhandItem);
     }
 
     @Environment(EnvType.CLIENT)

--- a/src/main/java/dev/adventurecraft/awakening/mixin/inventory/MixinPlayerInventory.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/inventory/MixinPlayerInventory.java
@@ -85,9 +85,7 @@ public abstract class MixinPlayerInventory implements ExPlayerInventory {
 
     // Method specifically not for the stuff that abuses swappOffhandWithMain method
     public void swapOffhandWithMainSlot() {
-        int slot = this.selected;
-        this.selected = this.offhandItem;
-        this.offhandItem = slot;
+        swapOffhandWithMain();
         // Update properties
         ((ExWorldProperties)this.player.level.levelData).setMainhandSlot(this.selected);
         ((ExWorldProperties)this.player.level.levelData).setOffhandSlot(this.offhandItem);

--- a/src/main/java/dev/adventurecraft/awakening/mixin/inventory/MixinPlayerInventory.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/inventory/MixinPlayerInventory.java
@@ -1,6 +1,7 @@
 package dev.adventurecraft.awakening.mixin.inventory;
 
 import com.llamalad7.mixinextras.sugar.Local;
+import dev.adventurecraft.awakening.extension.world.ExWorldProperties;
 import dev.adventurecraft.awakening.item.AC_IItemReload;
 import dev.adventurecraft.awakening.item.AC_Items;
 import dev.adventurecraft.awakening.item.AC_ISlotCallbackItem;
@@ -51,13 +52,23 @@ public abstract class MixinPlayerInventory implements ExPlayerInventory {
     //public int[] consumeInventory = new int[36];
 
     @Override
-    public int getOffhandItem() {
+    public int getOffhandSlot() {
         return this.offhandItem;
     }
 
     @Override
-    public void setOffhandItem(int value) {
+    public void setOffhandSlot(int value) {
         this.offhandItem = value;
+    }
+
+    @Override
+    public int getMainhandSlot() {
+        return this.selected;
+    }
+
+    @Override
+    public void setMainhandSlot(int value) {
+        this.selected = value;
     }
 
     public ItemInstance getOffhandItemStack() {
@@ -95,6 +106,9 @@ public abstract class MixinPlayerInventory implements ExPlayerInventory {
         if (this.selected == this.offhandItem) {
             this.offhandItem = slot;
         }
+        // Update properties
+        ((ExWorldProperties)this.player.level.levelData).setMainhandSlot(this.selected);
+        ((ExWorldProperties)this.player.level.levelData).setOffhandSlot(this.offhandItem);
     }
 
     private void onItemAddToSlot(int slot, ItemInstance stack) {

--- a/src/main/java/dev/adventurecraft/awakening/mixin/world/MixinWorld.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/world/MixinWorld.java
@@ -18,6 +18,7 @@ import dev.adventurecraft.awakening.extension.client.resource.language.ExTransla
 import dev.adventurecraft.awakening.extension.client.sound.ExSoundHelper;
 import dev.adventurecraft.awakening.extension.entity.ExBlockEntity;
 import dev.adventurecraft.awakening.extension.entity.ExEntity;
+import dev.adventurecraft.awakening.extension.inventory.ExPlayerInventory;
 import dev.adventurecraft.awakening.extension.world.ExWorld;
 import dev.adventurecraft.awakening.extension.world.ExWorldProperties;
 import dev.adventurecraft.awakening.extension.world.chunk.ExChunk;
@@ -1201,6 +1202,11 @@ public abstract class MixinWorld implements ExWorld, LevelSource {
             }
 
             this.firstTick = false;
+
+            for (Player player : this.players) {
+                ((ExPlayerInventory)player.inventory).setMainhandSlot(props.getMainhandSlot());
+                ((ExPlayerInventory)player.inventory).setOffhandSlot(props.getOffhandSlot());
+            }
         }
     }
 

--- a/src/main/java/dev/adventurecraft/awakening/mixin/world/MixinWorldProperties.java
+++ b/src/main/java/dev/adventurecraft/awakening/mixin/world/MixinWorldProperties.java
@@ -31,6 +31,8 @@ public abstract class MixinWorldProperties implements ExWorldProperties {
     private boolean canSleep = true;
     private boolean canUseHoe = true;
     private boolean canUseBonemeal = true;
+    private int mainHandSlot = 0;
+    private int offHandSlot = 1;
     public double tempOffset;
     private WorldGenProperties worldGenProps = new WorldGenProperties();
     public boolean iceMelts = true;
@@ -129,6 +131,9 @@ public abstract class MixinWorldProperties implements ExWorldProperties {
         this.canSleep = exTag.findBool("canSleep").orElse(true);
         this.canUseHoe = exTag.findBool("canUseHoe").orElse(true);
         this.canUseBonemeal = exTag.findBool("canUseBonemeal").orElse(true);
+
+        this.mainHandSlot = exTag.findInt("mainHandSlot").orElse(0);
+        this.offHandSlot = exTag.findInt("offHandSlot").orElse(1);
     }
 
     @Inject(
@@ -229,6 +234,8 @@ public abstract class MixinWorldProperties implements ExWorldProperties {
         tag.putBoolean("canSleep", this.canSleep);
         tag.putBoolean("canUseHoe", this.canUseHoe);
         tag.putBoolean("canUseBonemeal", this.canUseBonemeal);
+        tag.putInt("mainHandSlot",this.mainHandSlot);
+        tag.putInt("offHandSlot",this.offHandSlot);
     }
 
     @Override
@@ -587,4 +594,16 @@ public abstract class MixinWorldProperties implements ExWorldProperties {
     public @Override boolean getCanUseBonemeal() {
         return this.canUseBonemeal;
     }
+
+    @Override
+    public int getMainhandSlot(){return this.mainHandSlot;}
+
+    @Override
+    public void setMainhandSlot(int arg){this.mainHandSlot=arg;}
+
+    @Override
+    public int getOffhandSlot(){return this.offHandSlot;}
+
+    @Override
+    public void setOffhandSlot(int arg){this.offHandSlot=arg;}
 }

--- a/src/main/java/dev/adventurecraft/awakening/script/ScriptInventoryPlayer.java
+++ b/src/main/java/dev/adventurecraft/awakening/script/ScriptInventoryPlayer.java
@@ -74,7 +74,19 @@ public class ScriptInventoryPlayer extends ScriptInventory {
     }
 
     public void swapOffhandWithMain() {
-        ((ExPlayerInventory) this.invPlayer).swapOffhandWithMain();
+        ((ExPlayerInventory) this.invPlayer).swapOffhandWithMainSlot();
+    }
+
+    public void setMainhandSlot(int slot) {
+        if(slot >= 0 && slot <9) {
+            ((ExPlayerInventory) this.invPlayer).setMainhandSlot(slot);
+        }
+    }
+
+    public void setOffhandSlot(int slot) {
+        if(slot >= 0 && slot <9) {
+            ((ExPlayerInventory) this.invPlayer).setOffhandSlot(slot);
+        }
     }
 
     public boolean addItem(ScriptItem var1) {


### PR DESCRIPTION
- Fixes issue #60 
- Slots will be the same after rejoin, as they were when player left save (on a per save base)
- to work in each case (e.g. swapOffhandWithMain method) small cleanup and property update included
- 2 new methods, setMainhandSlot(int slot) / setOffhandSlot (int slot) so that you can finally actually set the slots in inv via script