### PR TITLE
[Fix] custom mob and NPC setOnCreated potential fix

### DIFF
--- a/src/main/java/dev/adventurecraft/awakening/entity/AC_EntityLivingScript.java
+++ b/src/main/java/dev/adventurecraft/awakening/entity/AC_EntityLivingScript.java
@@ -46,6 +46,8 @@ public class AC_EntityLivingScript extends Mob implements IEntityPather {
     private double prevDistToPoint = 999999.0D;
     private AC_TileEntityNpcPath triggerOnPath = null;
 
+    private boolean ranOnCreate = false;
+
     public AC_EntityLivingScript(Level world) {
         super(world);
         this.scope = ((ExWorld) world).getScript().getNewScope();
@@ -94,6 +96,9 @@ public class AC_EntityLivingScript extends Mob implements IEntityPather {
             }
 
             this.initDescTo = null;
+        }
+        if (!this.ranOnCreate) {
+            this.runCreatedScript();
         }
 
         this.prevWidth = this.bbWidth;
@@ -152,6 +157,7 @@ public class AC_EntityLivingScript extends Mob implements IEntityPather {
     }
 
     public void runCreatedScript() {
+        this.ranOnCreate = true;
         if (!this.onCreated.isEmpty()) {
             ((ExWorld) this.level).getScriptHandler().runScript(this.onCreated, this.scope);
         }
@@ -320,4 +326,8 @@ public class AC_EntityLivingScript extends Mob implements IEntityPather {
     public float getPrevHeight() {
         return prevHeight;
     }
+
+    public void setOnCreateRunFlag(boolean value) {this.ranOnCreate=value;}
+
+    public boolean getOnCreateRunFlag(){return this.ranOnCreate;}
 }

--- a/src/main/java/dev/adventurecraft/awakening/entity/AC_EntityNPC.java
+++ b/src/main/java/dev/adventurecraft/awakening/entity/AC_EntityNPC.java
@@ -19,8 +19,6 @@ public class AC_EntityNPC extends AC_EntityLivingScript {
     public boolean trackPlayer = true;
     public boolean isAttackable = false;
     public Entity entityToTrack = null;
-    private boolean ranOnCreate = false;
-
 
     public AC_EntityNPC(Level world) {
         super(world);
@@ -35,11 +33,6 @@ public class AC_EntityNPC extends AC_EntityLivingScript {
 
     @Override
     public void tick() {
-        if (!this.ranOnCreate) {
-            this.ranOnCreate = true;
-            this.runCreatedScript();
-        }
-
         if (this.pathToHome && !this.isPathing() && this.distanceToSqr(this.spawnX, this.spawnY, this.spawnZ) > 4.0D) {
             this.pathToPosition((int) this.spawnX, (int) this.spawnY, (int) this.spawnZ);
         }

--- a/src/main/java/dev/adventurecraft/awakening/script/ScriptEntityLivingScript.java
+++ b/src/main/java/dev/adventurecraft/awakening/script/ScriptEntityLivingScript.java
@@ -34,7 +34,7 @@ public class ScriptEntityLivingScript extends ScriptEntityLiving {
 
     public void setOnCreated(String var1) {
         this.entityLivingScript.onCreated = var1;
-        this.entityLivingScript.runCreatedScript();
+        this.entityLivingScript.setOnCreateRunFlag(false);
     }
 
     public String getOnUpdated() {


### PR DESCRIPTION
- adds ranOnCreate flag to EntityLivingScript + new runCreatedScript call concept and changes the way setOnCreated (class ScriptEntityLivingScript) works to not mess with mob scopes