### PR TITLE
Fix broken wiki table links

### DIFF
--- a/tools/test_wiki_quality.py
+++ b/tools/test_wiki_quality.py
@@ -4,7 +4,13 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from tools.wiki_quality import check_manifest, check_markdown, check_media, extract_urls
+from tools.wiki_quality import (
+    check_manifest,
+    check_markdown,
+    check_media,
+    check_wiki_links,
+    extract_urls,
+)
 
 
 class WikiQualityTests(unittest.TestCase):
@@ -52,6 +58,41 @@ class WikiQualityTests(unittest.TestCase):
             self.assertTrue(any("CRLF" in issue for issue in issues))
             self.assertTrue(any("misspelling" in issue for issue in issues))
             self.assertTrue(any("trailing whitespace" in issue for issue in issues))
+
+    def test_markdown_rejects_piped_wiki_links_in_tables(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "Current-Commands.md").write_text(
+                "# Current Commands\n\n| Syntax | Behavior |\n| --- | --- |\n"
+                "| [[Command config|`/config`]] | Opens config. |\n",
+                encoding="utf-8",
+            )
+            issues = check_markdown(root, allow_tokens=False, spellcheck=False)
+            self.assertTrue(
+                any("piped wiki link breaks Markdown table" in issue for issue in issues)
+            )
+
+    def test_markdown_allows_piped_wiki_link_example_in_fence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "Example.md").write_text(
+                "# Example\n\n```markdown\n| [[target|label]] |\n```\n",
+                encoding="utf-8",
+            )
+            issues = check_markdown(root, allow_tokens=False, spellcheck=False)
+            self.assertFalse(any("piped wiki link" in issue for issue in issues))
+
+    def test_wiki_links_validate_relative_markdown_destinations(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "Home.md").write_text(
+                "# Home\n\n[Works](Existing-Page) [Broken](Missing-Page)\n",
+                encoding="utf-8",
+            )
+            (root / "Existing-Page.md").write_text("# Existing\n", encoding="utf-8")
+            issues = check_wiki_links(root)
+            self.assertFalse(any("Existing-Page" in issue for issue in issues))
+            self.assertTrue(any("Missing-Page" in issue for issue in issues))
 
     def test_media_requires_alt_text_and_existing_file(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/tools/tests/test_wiki_script_api.py
+++ b/tools/tests/test_wiki_script_api.py
@@ -121,7 +121,11 @@ class RenderingTests(unittest.TestCase):
             )
             index = first["Scripting-API.md"].decode()
             beta = first["Scripting-API-Beta.md"].decode()
-            self.assertLess(index.index("|Alpha]]"), index.index("|Beta]]"))
+            self.assertLess(
+                index.index("[Alpha](Scripting-API-Alpha)"),
+                index.index("[Beta](Scripting-API-Beta)"),
+            )
+            self.assertNotIn("[[", index)
             self.assertIn("[[Scripting-API-Alpha|`Alpha`]]", beta)
             self.assertIn("## Other methods", beta)
             self.assertIn("https://example.invalid/repository/blob/main/Beta.java#L1", beta)

--- a/tools/wiki.py
+++ b/tools/wiki.py
@@ -183,6 +183,14 @@ def markdown_escape(value: str) -> str:
     return value.replace("|", "\\|").replace("\n", " ")
 
 
+def markdown_page_link(target: str, label: str, *, code: bool = False) -> str:
+    """Render an internal link that is safe inside a Markdown table cell."""
+    escaped = markdown_escape(label)
+    if code:
+        escaped = f"`{escaped}`"
+    return f"[{escaped}]({target})"
+
+
 def page_slug(value: str) -> str:
     slug = re.sub(r"[^A-Za-z0-9]+", "-", value).strip("-")
     if not slug:
@@ -426,7 +434,31 @@ def source_page_names() -> set[str]:
 
 
 def wiki_link_targets(markdown: str) -> set[str]:
-    return {match.group(1).strip().replace(" ", "-") for match in re.finditer(r"\[\[([^\]|#]+)", markdown)}
+    targets = {
+        match.group(1).strip().replace(" ", "-")
+        for match in re.finditer(r"\[\[([^\]|#]+)", markdown)
+    }
+    markdown_links = re.finditer(
+        r"(?<!!)\[(?:[^\]\n]|\](?!\())*\]\(([^)\n]+)\)", markdown
+    )
+    for match in markdown_links:
+        destination = match.group(1).strip()
+        if destination.startswith("<") and ">" in destination:
+            destination = destination[1 : destination.index(">")]
+        else:
+            destination = re.split(r"\s+[\"']", destination, maxsplit=1)[0]
+        parsed = urllib.parse.urlsplit(destination)
+        if parsed.scheme or parsed.netloc or destination.startswith(("/", "//", "#")):
+            continue
+        path = urllib.parse.unquote(parsed.path).strip()
+        if not path or "/" in path or "\\" in path:
+            continue
+        if path.casefold().endswith(".md"):
+            path = path[:-3]
+        elif Path(path).suffix:
+            continue
+        targets.add(path.replace(" ", "-"))
+    return targets
 
 
 def validate_current_evidence() -> None:
@@ -484,7 +516,8 @@ def render_blocks(entries: list[dict[str, object]]) -> str:
     for entry in entries:
         link = f"{source_url('src/main/java/dev/adventurecraft/awakening/tile/AC_Blocks.java')}#L{entry['line']}"
         target = feature_page_name("Block", str(entry["name"]))
-        lines.append(f"| [[{target}|{markdown_escape(str(entry['name']))}]] | {entry['id']} | `{entry['field']}` | [`{entry['class']}`]({link}) |")
+        name_link = markdown_page_link(target, str(entry["name"]))
+        lines.append(f"| {name_link} | {entry['id']} | `{entry['field']}` | [`{entry['class']}`]({link}) |")
     lines.extend(["", "See [[Fact-Checking-and-Provenance]] for how legacy block pages are handled.", ""])
     return "\n".join(lines)
 
@@ -501,7 +534,8 @@ def render_items(entries: list[dict[str, object]]) -> str:
     for entry in entries:
         link = f"{source_url('src/main/java/dev/adventurecraft/awakening/item/AC_Items.java')}#L{entry['line']}"
         target = feature_page_name("Item", str(entry["name"]))
-        lines.append(f"| [[{target}|{markdown_escape(str(entry['name']))}]] | {entry['id']} | `{entry['field']}` | [`{entry['class']}`]({link}) |")
+        name_link = markdown_page_link(target, str(entry["name"]))
+        lines.append(f"| {name_link} | {entry['id']} | `{entry['field']}` | [`{entry['class']}`]({link}) |")
     lines.append("")
     return "\n".join(lines)
 
@@ -518,7 +552,8 @@ def render_entities(entries: list[dict[str, object]]) -> str:
     for entry in entries:
         link = f"{source_url('src/main/java/dev/adventurecraft/awakening/mixin/entity/MixinEntityRegistry.java')}#L{entry['line']}"
         target = feature_page_name("Entity", str(entry["name"]))
-        lines.append(f"| [[{target}|{markdown_escape(str(entry['name']))}]] | {entry['id']} | [`{entry['class']}`]({link}) |")
+        name_link = markdown_page_link(target, str(entry["name"]))
+        lines.append(f"| {name_link} | {entry['id']} | [`{entry['class']}`]({link}) |")
     lines.append("")
     return "\n".join(lines)
 
@@ -541,7 +576,8 @@ def render_commands(commands: list[str], rules: list[dict[str, str]]) -> str:
     ]
     for name in commands:
         syntax, description, _ = COMMAND_DOCS[name]
-        lines.append(f"| [[Command {name}|{syntax}]] | {description} |")
+        syntax_link = markdown_page_link(f"Command-{name}", syntax, code=True)
+        lines.append(f"| {syntax_link} | {description} |")
     lines.extend(
         [
             "",
@@ -700,16 +736,16 @@ def render_alias_pages(
         if len(targets) == 1:
             label, target = targets[0]
             lines.extend([f"This term refers to [[{target}|{label}: {display_name}]].", ""])
-            target_text = f"[[{target}|{display_name}]]"
+            target_text = markdown_page_link(target, display_name)
         else:
             lines.extend(["This name is used by more than one current registry entry:", ""])
             lines.extend(f"- [[{target}|{label}: {display_name}]]" for label, target in targets)
             lines.append("")
-            target_text = ", ".join(f"[[{target}|{label}]]" for label, target in targets)
+            target_text = ", ".join(markdown_page_link(target, label) for label, target in targets)
         lines.extend(["This alias adds no behavior claims. See the target page for source evidence.", ""])
         pages[f"{alias_name}.md"] = "\n".join(lines)
         evidence[alias_name] = ["wiki/feature-details.json", "wiki/fandom-baseline.json"]
-        index_lines.append(f"| [[{alias_name}|{markdown_escape(display_name)}]] | {target_text} |")
+        index_lines.append(f"| {markdown_page_link(alias_name, display_name)} | {target_text} |")
     index_lines.append("")
     pages["Aliases.md"] = "\n".join(index_lines)
     evidence["Aliases"] = ["wiki/feature-details.json", "wiki/fandom-baseline.json"]
@@ -974,7 +1010,7 @@ def validate() -> None:
             content = read_text(path)
             for target in wiki_link_targets(content):
                 if target not in page_names:
-                    errors.append(f"{path.name}: broken wiki link [[{target}]]")
+                    errors.append(f"{path.name}: broken internal wiki link {target!r}")
         forbidden = {
             "JDK **21**": "current build requires Java 25",
             "Java **21**": "current build requires Java 25",

--- a/tools/wiki_quality.py
+++ b/tools/wiki_quality.py
@@ -30,8 +30,10 @@ MISSPELLINGS = {
     "wether": "whether",
 }
 MARKDOWN_IMAGE_RE = re.compile(r"!\[([^\]]*)\]\(([^)]+)\)")
+MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[(?:[^\]\n]|\](?!\())*\]\(([^)\n]+)\)")
 HTML_IMAGE_RE = re.compile(r"<img\b([^>]*)>", re.IGNORECASE)
 WIKI_LINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+PIPED_WIKI_LINK_RE = re.compile(r"\[\[[^\]\n]*\|[^\]\n]*\]\]")
 URL_RE = re.compile(r"https?://[^\s<>\"\]]+")
 TOKEN_RE = re.compile(r"\{\{[A-Z0-9_]+\}\}")
 
@@ -107,7 +109,6 @@ def check_markdown(root: Path, *, allow_tokens: bool, spellcheck: bool) -> list[
                 issues.append(f"{rel}:{number}: trailing whitespace")
             if "\t" in line:
                 issues.append(f"{rel}:{number}: tab character; use spaces")
-
             fence = re.match(r"^\s*(`{3,}|~{3,})", line)
             if fence:
                 current = fence.group(1)[0]
@@ -121,6 +122,11 @@ def check_markdown(root: Path, *, allow_tokens: bool, spellcheck: bool) -> list[
                 continue
             if in_fence:
                 continue
+            if line.lstrip().startswith("|") and PIPED_WIKI_LINK_RE.search(line):
+                issues.append(
+                    f"{rel}:{number}: piped wiki link breaks Markdown table columns; "
+                    "use a standard Markdown link"
+                )
 
             heading = re.match(r"^(#{1,6})\s+\S", line)
             if heading:
@@ -330,6 +336,25 @@ def check_wiki_links(root: Path) -> list[str]:
             if keys.isdisjoint(normalized):
                 line = text.count("\n", 0, match.start()) + 1
                 issues.append(f"{display_path(path, root)}:{line}: broken wiki link [[{raw}]]")
+        for match in MARKDOWN_LINK_RE.finditer(text):
+            destination = split_destination(match.group(1))
+            parsed = urllib.parse.urlsplit(destination)
+            if parsed.scheme or parsed.netloc or destination.startswith(("/", "//", "#")):
+                continue
+            target = urllib.parse.unquote(parsed.path).strip()
+            if not target or "/" in target or "\\" in target:
+                continue
+            if target.casefold().endswith(".md"):
+                target = target[:-3]
+            elif Path(target).suffix:
+                continue
+            key = target.casefold().replace(" ", "-")
+            if key not in normalized:
+                line = text.count("\n", 0, match.start()) + 1
+                issues.append(
+                    f"{display_path(path, root)}:{line}: broken Markdown wiki link "
+                    f"[{target}]"
+                )
     return issues
 
 

--- a/tools/wiki_script_api.py
+++ b/tools/wiki_script_api.py
@@ -403,15 +403,23 @@ def wiki_page_name(type_name: str) -> str:
     return f"Scripting-API-{type_name}"
 
 
+def markdown_table_link(target: str, label: str) -> str:
+    """Render an internal link without Gollum's table-breaking pipe syntax."""
+    escaped = label.replace("|", "\\|")
+    return f"[{escaped}]({target})"
+
+
 def source_url(api_type: ApiType, base_url: str, line: int | None = None) -> str:
     url = f"{base_url.rstrip('/')}/{api_type.source_path}"
     return f"{url}#L{line}" if line else url
 
 
-def type_reference(value: str, local_names: set[str]) -> str:
+def type_reference(value: str, local_names: set[str], *, in_table: bool = False) -> str:
     simple_name_match = re.match(r"(?:[\w$.]+\.)?([A-Za-z_$][\w$]*)", value)
     if simple_name_match and simple_name_match.group(1) in local_names:
         name = simple_name_match.group(1)
+        if in_table:
+            return markdown_table_link(wiki_page_name(name), f"`{value}`")
         return f"[[{wiki_page_name(name)}|`{value}`]]"
     return f"`{value}`"
 
@@ -499,9 +507,12 @@ def render_index(
     local_names = {item.name for item in api_types}
     for api_type in api_types:
         inheritance_values = api_type.extends + api_type.implements
-        inheritance = ", ".join(type_reference(value, local_names) for value in inheritance_values) or "—"
+        inheritance = ", ".join(
+            type_reference(value, local_names, in_table=True) for value in inheritance_values
+        ) or "—"
+        type_link = markdown_table_link(wiki_page_name(api_type.name), api_type.name)
         lines.append(
-            f"| [[{wiki_page_name(api_type.name)}|{api_type.name}]] | {api_type.kind} | "
+            f"| {type_link} | {api_type.kind} | "
             f"{inheritance} | {len(api_type.members)} |"
         )
     lines.append("")


### PR DESCRIPTION
## Summary

- render internal links inside generated tables with standard Markdown instead of pipe-delimited Gollum markup
- fix 417 broken links across 289 rows in Commands, Blocks, Items, Entities, Aliases, and the Scripting API index
- validate relative Markdown wiki destinations and reject table-breaking wiki-link markup in CI

## Root cause

GitHub parses the `|` in `[[target|label]]` as a Markdown table column delimiter before rendering the wiki link. That split links into visible fragments such as `[[Command config` and `/config]]`.

## Validation

- validated and rebuilt 290 generated pages from 178 retained baseline records
- authored and generated wiki quality checks pass
- 12 Python unit tests pass
- generated output contains zero pipe-delimited wiki links in table rows